### PR TITLE
LPS-61127 Implement new alert in success taglib

### DIFF
--- a/modules/frontend/frontend-js-web/src/main/resources/META-INF/resources/liferay/alert.js
+++ b/modules/frontend/frontend-js-web/src/main/resources/META-INF/resources/liferay/alert.js
@@ -3,9 +3,9 @@ AUI.add(
 	function(A) {
 		var Lang = A.Lang;
 
-		var TPL_ALERTS_CONTAINER = '<div class="lfr-alert-container"></div>';
-
 		var TPL_ALERT_NODE = '<div class="container-fluid-1280 lfr-alert-wrapper"></div>';
+
+		var TPL_ALERTS_CONTAINER = '<div class="lfr-alert-container"></div>';
 
 		var TPL_CONTENT = '<strong class="lead">{title}</strong>{message}';
 

--- a/portal-web/docroot/html/common/themes/portlet_messages.jspf
+++ b/portal-web/docroot/html/common/themes/portlet_messages.jspf
@@ -59,12 +59,12 @@ else if (group.isStagingGroup()) {
 </c:if>
 
 <c:if test='<%= MultiSessionMessages.contains(renderRequest, "requestProcessed") && !MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE) %>'>
-	<div class="alert alert-success">
 
-		<%
-		String successMessage = (String)MultiSessionMessages.get(renderRequest, "requestProcessed");
-		%>
+	<%
+	String successMessage = (String)MultiSessionMessages.get(renderRequest, "requestProcessed");
+	%>
 
+	<liferay-util:buffer var="successHtml">
 		<c:choose>
 			<c:when test='<%= Validator.isNotNull(successMessage) && !successMessage.equals("request_processed") %>'>
 				<%= HtmlUtil.escape(successMessage) %>
@@ -82,7 +82,12 @@ else if (group.isStagingGroup()) {
 
 			<liferay-ui:message arguments="<%= taglibMessage %>" key="the-page-will-be-refreshed-when-you-close-this-dialog.alternatively-you-can-hide-this-dialog-x" translateArguments="<%= false %>" />
 		</c:if>
-	</div>
+	</liferay-util:buffer>
+
+	<liferay-ui:success
+		key="requestProcessed"
+		message="<%= successHtml %>"
+	/>
 </c:if>
 
 <liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_CONFIGURATION %>" message="you-have-successfully-updated-the-setup" />

--- a/portal-web/docroot/html/taglib/ui/alert/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/alert/page.jsp
@@ -16,8 +16,8 @@
 
 <%@ include file="/html/taglib/ui/alert/init.jsp" %>
 
-<aui:script use="liferay-portlet-alert">
-	new Liferay.Portlet.Alert(
+<aui:script use="liferay-alert">
+	new Liferay.Alert(
 		{
 			closeable: <%= closeable %>,
 			delay: {

--- a/portal-web/docroot/html/taglib/ui/success/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/success/page.jsp
@@ -20,17 +20,17 @@
 String key = (String)request.getAttribute("liferay-ui:success:key");
 String message = (String)request.getAttribute("liferay-ui:success:message");
 boolean translateMessage = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:success:translateMessage"));
+
+if (translateMessage) {
+	message = LanguageUtil.get(request, message);
+}
 %>
 
 <c:if test="<%= MultiSessionMessages.contains(portletRequest, key) %>">
-	<div class="alert alert-success">
-		<c:choose>
-			<c:when test="<%= translateMessage %>">
-				<%= LanguageUtil.get(request, message) %>
-			</c:when>
-			<c:otherwise>
-				<%= message %>
-			</c:otherwise>
-		</c:choose>
-	</div>
+	<liferay-ui:alert
+		message="<%= message %>"
+		timeout="5000"
+		title='<%= LanguageUtil.get(request, "success") %>'
+		type="success"
+	/>
 </c:if>


### PR DESCRIPTION
Hey Evan!

This PR changes the success messages to use the new Lexicon format. They now show inside an `lfr-alert-container` in the portlet.

This breaks several functional tests, but hopefully should be easy to fix.

Could you please take a look?

Thanks!