### PR TITLE
LPS-61127 Implement new alert in success taglib

### DIFF
--- a/portal-web/docroot/html/common/themes/portlet_messages.jspf
+++ b/portal-web/docroot/html/common/themes/portlet_messages.jspf
@@ -59,12 +59,12 @@ else if (group.isStagingGroup()) {
 </c:if>
 
 <c:if test='<%= MultiSessionMessages.contains(renderRequest, "requestProcessed") && !MultiSessionMessages.contains(renderRequest, portlet.getPortletId() + SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE) %>'>
-	<div class="alert alert-success">
 
-		<%
-		String successMessage = (String)MultiSessionMessages.get(renderRequest, "requestProcessed");
-		%>
+	<%
+	String successMessage = (String)MultiSessionMessages.get(renderRequest, "requestProcessed");
+	%>
 
+	<liferay-util:buffer var="successHtml">
 		<c:choose>
 			<c:when test='<%= Validator.isNotNull(successMessage) && !successMessage.equals("request_processed") %>'>
 				<%= HtmlUtil.escape(successMessage) %>
@@ -82,7 +82,12 @@ else if (group.isStagingGroup()) {
 
 			<liferay-ui:message arguments="<%= taglibMessage %>" key="the-page-will-be-refreshed-when-you-close-this-dialog.alternatively-you-can-hide-this-dialog-x" translateArguments="<%= false %>" />
 		</c:if>
-	</div>
+	</liferay-util:buffer>
+
+	<liferay-ui:success
+		key="requestProcessed"
+		message="<%= successHtml %>"
+	/>
 </c:if>
 
 <liferay-ui:success key="<%= portlet.getPortletId() + SessionMessages.KEY_SUFFIX_UPDATED_CONFIGURATION %>" message="you-have-successfully-updated-the-setup" />

--- a/portal-web/docroot/html/taglib/ui/success/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/success/page.jsp
@@ -20,17 +20,17 @@
 String key = (String)request.getAttribute("liferay-ui:success:key");
 String message = (String)request.getAttribute("liferay-ui:success:message");
 boolean translateMessage = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:success:translateMessage"));
+
+if (translateMessage) {
+	message = LanguageUtil.get(request, message);
+}
 %>
 
 <c:if test="<%= MultiSessionMessages.contains(portletRequest, key) %>">
-	<div class="alert alert-success">
-		<c:choose>
-			<c:when test="<%= translateMessage %>">
-				<%= LanguageUtil.get(request, message) %>
-			</c:when>
-			<c:otherwise>
-				<%= message %>
-			</c:otherwise>
-		</c:choose>
-	</div>
+	<liferay-ui:alert
+		message="<%= message %>"
+		timeout="5000"
+		title='<%= LanguageUtil.get(request, "success") %>'
+		type="success"
+	/>
 </c:if>


### PR DESCRIPTION
Hi Evan!

This PR changes the success messages to use the new Lexicon format. They now show inside an lfr-alert-container in the portlet. This breaks several functional tests, but should not break anything else like sign in portlet with the error messages taglib.

Could you please take a look?

Thanks!