### PR TITLE
LPS-61550 Only show edit page link for the current page

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
@@ -189,6 +189,34 @@ body {
 	}
 }
 
+/* Layouts Tree */
+
+.product-menu {
+	.tree-node-content {
+		.layout-tree-edit {
+			opacity: 0;
+
+			&:focus {
+				opacity: 1;
+			}
+		}
+
+		&.tree-node-selected, &:active, &.active, &:hover {
+			.tree-label {
+				> .layout-tree-edit {
+					opacity: 1;
+				}
+			}
+		}
+
+		.layout-tree:focus ~ .layout-tree-edit {
+			opacity: 1;
+		}
+
+	}
+}
+
+
 /* Icon Animation */
 
 .toast-animation {


### PR DESCRIPTION
Hey Evan, 

this hides most of the links to edit a page from the tree and they become visible when hovering the mouse (or focusing with the keyboard). The link from the selected page are also visible.

Let me know if I can help you, 
thanks!

<img width="317" alt="welcome_-_liferay" src="https://cloud.githubusercontent.com/assets/203395/12038698/8c04d306-ae5a-11e5-86ef-88479049235d.png">
