### PR TITLE
LPS-60244 Add lang key

### DIFF
--- a/modules/frontend/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/frontend/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -221,6 +221,13 @@ if (showSource) {
 
 		var editorConfig = <%= Validator.isNotNull(editorConfigJSONObject) %> ? <%= editorConfigJSONObject %> : {};
 
+		editorConfig = A.merge(
+			{
+				title: '<%= LanguageUtil.get(request, "rich-text-format") %>'
+			},
+			editorConfig
+		);
+
 		var plugins = [];
 
 		<c:if test="<%= Validator.isNotNull(data) && Validator.isNotNull(uploadURL) %>">

--- a/modules/frontend/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/frontend/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -223,7 +223,7 @@ if (showSource) {
 
 		editorConfig = A.merge(
 			{
-				title: '<%= LanguageUtil.get(request, "rich-text-format") %>'
+				title: '<%= LanguageUtil.get(request, "rich-text-editor") %>'
 			},
 			editorConfig
 		);

--- a/modules/frontend/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
+++ b/modules/frontend/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
@@ -46,11 +46,6 @@ AUI.add(
 					textMode: {
 						validator: Lang.isBoolean,
 						value: {}
-					},
-
-					title: {
-						validator: Lang.isString,
-						value: ''
 					}
 				},
 

--- a/modules/frontend/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
+++ b/modules/frontend/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/alloyeditor.js
@@ -46,6 +46,11 @@ AUI.add(
 					textMode: {
 						validator: Lang.isBoolean,
 						value: {}
+					},
+
+					title: {
+						validator: Lang.isString,
+						value: ''
 					}
 				},
 

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -3936,6 +3936,7 @@ reviewer=Reviewer
 reviewers=Reviewers
 revision=Revision
 rich=Rich
+rich-text-editor=Rich Text Editor
 rich-text-format=Rich Text Format
 ridge=Ridge
 right=Right


### PR DESCRIPTION
Test is failing probably because of this title locator https://github.com/jbalsas/liferay-portal/blob/master/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/WebDriverHelper.java#L547

Couldn't we use `id` instead?