### PR TITLE
LPS-63809 add panel should remember if it was open in applications or content

### DIFF
--- a/modules/apps/web-experience-management/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_panel.jsp
+++ b/modules/apps/web-experience-management/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/add_panel.jsp
@@ -39,7 +39,7 @@
 
 					boolean hasAddContentPermission = hasAddApplicationsPermission && !group.isLayoutPrototype();
 
-					String selectedTab = GetterUtil.getString(SessionClicks.get(request, "com.liferay.product.navigation.control.menu.web_addPanelTab", "content"));
+					String selectedTab = GetterUtil.getString(SessionClicks.get(request, "com.liferay.product.navigation.control.menu.web_addPanelTab", hasAddContentPermission ? "content" : "applications"));
 					%>
 
 					<div aria-multiselectable="true" class="panel-group" id="<portlet:namespace />Accordion" role="tablist">
@@ -57,7 +57,7 @@
 									</div>
 								</div>
 
-								<div aria-expanded="false" aria-labelledby="<portlet:namespace />addApplicationHeading" class="collapse panel-collapse <%= selectedTab.equals("applications") ? "in" : StringPool.BLANK %>" id="<portlet:namespace />addApplicationCollapse" role="tabpanel">
+								<div aria-expanded="false" aria-labelledby="<portlet:namespace />addApplicationHeading" class="collapse panel-collapse <%= selectedTab.equals("applications") ? "in" : StringPool.BLANK %>" data-value="applications" id="<portlet:namespace />addApplicationCollapse" role="tabpanel">
 									<div class="panel-body">
 										<liferay-util:include page="/add_application.jsp" servletContext="<%= application %>" />
 									</div>
@@ -79,12 +79,23 @@
 									</div>
 								</div>
 
-								<div aria-expanded="false" aria-labelledby="<portlet:namespace />addContentHeading" class="collapse panel-collapse <%= selectedTab.equals("content") ? "in" : StringPool.BLANK %>" id="<portlet:namespace />addContentCollapse" role="tabpanel">
+								<div aria-expanded="false" aria-labelledby="<portlet:namespace />addContentHeading" class="collapse panel-collapse <%= selectedTab.equals("content") ? "in" : StringPool.BLANK %>" data-value="content" id="<portlet:namespace />addContentCollapse" role="tabpanel">
 									<div class="panel-body">
 										<liferay-util:include page="/add_content.jsp" servletContext="<%= application %>" />
 									</div>
 								</div>
 							</div>
+						</c:if>
+
+						<c:if test="<%= hasAddApplicationsPermission && hasAddContentPermission %>">
+							<aui:script use="liferay-store">
+								$('#<portlet:namespace />Accordion').on(
+									'show.bs.collapse',
+									function(event) {
+										Liferay.Store('com.liferay.product.navigation.control.menu.web_addPanelTab', event.target.getAttribute('data-value'));
+									}
+								);
+							</aui:script>
 						</c:if>
 					</div>
 

--- a/modules/apps/web-experience-management/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_content.js
+++ b/modules/apps/web-experience-management/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu_add_content.js
@@ -51,7 +51,6 @@ AUI.add(
 						instance._eventHandles.push(
 							instance._entriesPanel.delegate(STR_CLICK, instance._addContent, SELECTOR_ADD_CONTENT_ITEM, instance),
 							Liferay.on('AddContent:refreshContentList', instance._refreshContentList, instance),
-							Liferay.on('showTab', instance._onShowTab, instance),
 							Liferay.on(
 								'AddContent:addPortlet',
 								function(event) {
@@ -59,16 +58,6 @@ AUI.add(
 								}
 							)
 						);
-					},
-
-					_onShowTab: function(event) {
-						var instance = this;
-
-						if (event.namespace.indexOf(instance.get('namespace')) === 0) {
-							var index = event.selectedIndex;
-
-							Liferay.Store('com.liferay.product.navigation.control.menu.web_addPanelTab', event.names[index]);
-						}
 					},
 
 					_refreshContentList: function(event) {


### PR DESCRIPTION
<img width="1316" alt="welcome2_-_liferay" src="https://cloud.githubusercontent.com/assets/203395/13436397/5d4e94fa-dfdf-11e5-9d2e-703a9b9e0c86.png">

Now if you open "add > Applications". Next time you open the panel, it will remember it was in "applications" and not in "content". 
