### PR TITLE
master-lps-66451

### DIFF
--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
@@ -129,19 +129,6 @@ public class SiteAdminDisplayContext {
 		return _groupId;
 	}
 
-	public Map<Long, Integer> getGroupUsersCount(long[] groupIds)
-		throws PortalException {
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		Company company = themeDisplay.getCompany();
-
-		return UserLocalServiceUtil.searchCounts(
-			company.getCompanyId(), WorkflowConstants.STATUS_APPROVED,
-			groupIds);
-	}
-
 	public String getKeywords() {
 		if (_keywords == null) {
 			_keywords = ParamUtil.getString(_request, "keywords");
@@ -210,53 +197,6 @@ public class SiteAdminDisplayContext {
 		return searchURL;
 	}
 
-	public PortletURL getSiteAdministrationPortletURL(Group group)
-		throws PortalException {
-
-		PortletURL siteAdministrationURL = null;
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)_request.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		PermissionChecker permissionChecker =
-			themeDisplay.getPermissionChecker();
-
-		PanelCategoryHelper panelCategoryHelper =
-			(PanelCategoryHelper)_request.getAttribute(
-				ApplicationListWebKeys.PANEL_CATEGORY_HELPER);
-
-		String portletId = null;
-
-		if (panelCategoryHelper != null) {
-			portletId = panelCategoryHelper.getFirstPortletId(
-				PanelCategoryKeys.SITE_ADMINISTRATION, permissionChecker,
-				group);
-		}
-
-		if (Validator.isNotNull(portletId)) {
-			siteAdministrationURL = PortalUtil.getControlPanelPortletURL(
-				_request, group, portletId, 0, 0, PortletRequest.RENDER_PHASE);
-		}
-
-		return siteAdministrationURL;
-	}
-
-	public PortletURL getSiteAdministrationURL(long groupId) {
-		PortletURL siteAdministrationURL =
-			_liferayPortletResponse.createRenderURL();
-
-		siteAdministrationURL.setParameter("mvcPath", "/edit_site.jsp");
-		siteAdministrationURL.setParameter(
-			"redirect", getCurrentURL().toString());
-		siteAdministrationURL.setParameter("groupId", String.valueOf(groupId));
-
-		return siteAdministrationURL;
-	}
-
-	public int getUserGroupsCount() throws PortalException {
-		return getUserGroupsCount(getGroup());
-	}
-
 	public int getUserGroupsCount(Group group) {
 		LinkedHashMap<String, Object> userGroupParams = new LinkedHashMap<>();
 
@@ -271,10 +211,6 @@ public class SiteAdminDisplayContext {
 
 		return UserGroupLocalServiceUtil.searchCount(
 			company.getCompanyId(), null, userGroupParams);
-	}
-
-	public int getUsersCount() throws PortalException {
-		return getUsersCount(getGroup());
 	}
 
 	public int getUsersCount(Group group) {

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
@@ -14,9 +14,6 @@
 
 package com.liferay.site.admin.web.internal.display.context;
 
-import com.liferay.application.list.constants.ApplicationListWebKeys;
-import com.liferay.application.list.constants.PanelCategoryKeys;
-import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
@@ -53,9 +50,7 @@ import com.liferay.site.constants.SiteWebKeys;
 import com.liferay.site.util.GroupSearchProvider;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 
-import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
 
 import javax.servlet.http.HttpServletRequest;

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/SiteAdminPortlet.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/SiteAdminPortlet.java
@@ -14,10 +14,6 @@
 
 package com.liferay.site.admin.web.internal.portlet;
 
-import com.liferay.application.list.PanelAppRegistry;
-import com.liferay.application.list.PanelCategoryRegistry;
-import com.liferay.application.list.constants.ApplicationListWebKeys;
-import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
 import com.liferay.asset.kernel.exception.AssetCategoryException;
 import com.liferay.asset.kernel.exception.AssetTagException;
 import com.liferay.exportimport.kernel.exception.RemoteExportException;
@@ -329,12 +325,6 @@ public class SiteAdminPortlet extends MVCPortlet {
 		renderRequest.setAttribute(
 			SiteWebKeys.GROUP_URL_PROVIDER, groupURLProvider);
 
-		PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(
-			panelAppRegistry, panelCategoryRegistry);
-
-		renderRequest.setAttribute(
-			ApplicationListWebKeys.PANEL_CATEGORY_HELPER, panelCategoryHelper);
-
 		if (SessionErrors.contains(
 				renderRequest, NoSuchBackgroundTaskException.class.getName()) ||
 			SessionErrors.contains(
@@ -539,18 +529,6 @@ public class SiteAdminPortlet extends MVCPortlet {
 		MembershipRequestService membershipRequestService) {
 
 		this.membershipRequestService = membershipRequestService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setPanelAppRegistry(PanelAppRegistry panelAppRegistry) {
-		this.panelAppRegistry = panelAppRegistry;
-	}
-
-	@Reference(unbind = "-")
-	protected void setPanelCategoryRegistry(
-		PanelCategoryRegistry panelCategoryRegistry) {
-
-		this.panelCategoryRegistry = panelCategoryRegistry;
 	}
 
 	@Reference(unbind = "-")
@@ -941,8 +919,6 @@ public class SiteAdminPortlet extends MVCPortlet {
 	protected LayoutSetService layoutSetService;
 	protected MembershipRequestLocalService membershipRequestLocalService;
 	protected MembershipRequestService membershipRequestService;
-	protected PanelAppRegistry panelAppRegistry;
-	protected PanelCategoryRegistry panelCategoryRegistry;
 	protected RoleLocalService roleLocalService;
 	protected TeamLocalService teamLocalService;
 	protected UserLocalService userLocalService;

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/SiteAdminPortlet.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/SiteAdminPortlet.java
@@ -95,6 +95,7 @@ import com.liferay.portal.liveusers.LiveUsers;
 import com.liferay.site.admin.web.internal.constants.SiteAdminPortletKeys;
 import com.liferay.site.constants.SiteWebKeys;
 import com.liferay.site.util.GroupSearchProvider;
+import com.liferay.site.util.GroupURLProvider;
 import com.liferay.sites.kernel.util.Sites;
 import com.liferay.sites.kernel.util.SitesUtil;
 
@@ -325,6 +326,9 @@ public class SiteAdminPortlet extends MVCPortlet {
 		renderRequest.setAttribute(
 			SiteWebKeys.GROUP_SEARCH_PROVIDER, groupSearchProvider);
 
+		renderRequest.setAttribute(
+			SiteWebKeys.GROUP_URL_PROVIDER, groupURLProvider);
+
 		PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(
 			panelAppRegistry, panelCategoryRegistry);
 
@@ -490,6 +494,11 @@ public class SiteAdminPortlet extends MVCPortlet {
 	@Reference(unbind = "-")
 	protected void setGroupService(GroupService groupService) {
 		this.groupService = groupService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setGroupURLProvider(GroupURLProvider groupURLProvider) {
+		this.groupURLProvider = groupURLProvider;
 	}
 
 	@Reference(unbind = "-")
@@ -925,6 +934,7 @@ public class SiteAdminPortlet extends MVCPortlet {
 	protected GroupLocalService groupLocalService;
 	protected GroupSearchProvider groupSearchProvider;
 	protected GroupService groupService;
+	protected GroupURLProvider groupURLProvider;
 	protected LayoutLocalService layoutLocalService;
 	protected LayoutSetLocalService layoutSetLocalService;
 	protected LayoutSetPrototypeService layoutSetPrototypeService;

--- a/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -111,6 +111,8 @@ page import="com.liferay.ratings.kernel.transformer.RatingsDataTransformerUtil" 
 page import="com.liferay.site.admin.web.internal.constants.SiteAdminPortletKeys" %><%@
 page import="com.liferay.site.admin.web.internal.constants.SiteAdminWebKeys" %><%@
 page import="com.liferay.site.admin.web.internal.display.context.SiteAdminDisplayContext" %><%@
+page import="com.liferay.site.constants.SiteWebKeys" %><%@
+page import="com.liferay.site.util.GroupURLProvider" %><%@
 page import="com.liferay.sites.kernel.util.Sites" %><%@
 page import="com.liferay.sites.kernel.util.SitesUtil" %>
 

--- a/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/site_action.jsp
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/site_action.jsp
@@ -57,18 +57,6 @@ boolean hasUpdatePermission = GroupPermissionUtil.contains(permissionChecker, gr
 		url="<%= editURL %>"
 	/>
 
-	<%
-	PortletURL siteAdministrationURL = siteAdminDisplayContext.getSiteAdministrationPortletURL(group);
-	%>
-
-	<c:if test="<%= siteAdministrationURL != null %>">
-		<liferay-ui:icon
-			message="site-administration"
-			method="get"
-			url="<%= siteAdministrationURL.toString() %>"
-		/>
-	</c:if>
-
 	<c:if test="<%= hasUpdatePermission %>">
 
 		<%

--- a/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -57,14 +57,9 @@ siteChecker.setRememberCheckBoxStateURLRegex("^(?!.*" + liferayPortletResponse.g
 			viewSubsitesURL.setParameter("groupId", String.valueOf(curGroup.getGroupId()));
 		}
 
-		String viewSiteURL = StringPool.BLANK;
+		GroupURLProvider groupURLProvider = (GroupURLProvider)request.getAttribute(SiteWebKeys.GROUP_URL_PROVIDER);
 
-		if (curGroup.getPublicLayoutsPageCount() > 0) {
-			viewSiteURL = curGroup.getDisplayURL(themeDisplay, false);
-		}
-		else if (curGroup.getPrivateLayoutsPageCount() > 0) {
-			viewSiteURL = curGroup.getDisplayURL(themeDisplay, true);
-		}
+		String viewSiteURL = groupURLProvider.getGroupURL(curGroup, liferayPortletRequest);
 		%>
 
 		<c:choose>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Page.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Page.macro
@@ -142,8 +142,9 @@
 			<then>
 				<execute function="Type" locator1="NavBar#BASIC_SEARCH_FIELD" value1="${siteName}" />
 				<execute function="Click" locator1="Icon#BASIC_SEARCH" />
-				<execute function="Click#waitForMenuToggleJSClick" locator1="Sites#SITE_TABLE_ACTIONS" />
-				<execute function="AssertClick" locator1="MenuItem#SITE_ADMINISTRATION" value1="Site Administration" />
+				<execute function="AssertClick" locator1="ContentRow#ENTRY_CONTENT_ENTRY_NAME_LINK" value1="${siteName}">
+					<var name="key_rowEntry" value="${siteName}" />
+				</execute>
 			</then>
 		</if>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/usecase/XssUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/usecase/XssUsecase.testcase
@@ -131,9 +131,7 @@
 
 		<var name="key_rowEntry" value="${siteName}" />
 
-		<execute function="ClickNoError#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#SITE_ADMINISTRATION" value1="Site Administration" />
+		<execute function="AssertClick" locator1="ContentRow#ENTRY_CONTENT_ENTRY_NAME_LINK" value1="${siteName}" />
 
 		<execute function="AssertAlertNotPresent" />
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-66451
https://issues.liferay.com/browse/LRQA-26995

These changes should only be applied on **master.**

cc @juliocamarero I've updated our acceptance tests to reflect the new navigation to administer a site by clicking the site link instead of using the "Site Administration" menu item from the site actions menu.

@xbrianlee It looks like some tests within `CPRolesCPSites.testcase` will need to be updated because "Site Administration"is no longer a menu item within the site actions menu, but since they are not acceptance tests, I will let the Core Infrastructure team decide how to best handle the test fixes.

@liulukiwi @GinsonRen This change removes the menu item "Site Administration" from the menu in Sites portlet. To go to site administration, the user should click the site link in the Sites portlet instead.

![site-administration-menu-item-removed](https://cloud.githubusercontent.com/assets/8292593/17409766/6e54bb1a-5a25-11e6-9e68-7215b44aaf51.PNG)
